### PR TITLE
Rename feature sling-scripting-sightly to sling-scripting-htl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.karaf-configs</artifactId>
       <version>0.1.1-SNAPSHOT</version>
-      <classifier>org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-scripting_sightly</classifier>
+      <classifier>org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-scripting_htl</classifier>
       <type>config</type>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
Configuration file renamed. Please see Sling Jira ISSUE: https://issues.apache.org/jira/browse/SLING-8763. Related issue https://issues.apache.org/jira/projects/SLING/issues/SLING-8685